### PR TITLE
Add a "json=" option to specify output file name

### DIFF
--- a/src/AmplInterface.cpp
+++ b/src/AmplInterface.cpp
@@ -21,6 +21,7 @@ AmplInterface::AmplInterface(int argc, char**& argv)
    primal_assumed_(1.0),
    dual_assumed_(1.0),
    stubname_(""),
+   jsonname_(""),
    objn_(-1),
    obj_sense_(0),
    nnz_hes_lag_(-1)
@@ -46,7 +47,7 @@ AmplInterface::AmplInterface(int argc, char**& argv)
    Oinfo_ptr_->sname = new char[strlen(sname)+1];
    strcpy(Oinfo_ptr_->sname, sname);
 
-   char bsname[] = "gjh_asl_json: Version 1.0.0";
+   char bsname[] = "gjh_asl_json: Version 1.1.0";
    Oinfo_ptr_->bsname = new char[strlen(bsname)+1];
    strcpy(Oinfo_ptr_->bsname, bsname);
 
@@ -57,6 +58,7 @@ AmplInterface::AmplInterface(int argc, char**& argv)
    int options_count = 5;
    char* rows_res(NULL);
    char* cols_res(NULL);
+   char* json_res(NULL);
    keyword keywords[] = {/* must be alphabetical */
       /* one may notice that I'm going overboard here to shut up warnings
 	 about 'deprecated conversion from string const to char*' */
@@ -72,6 +74,10 @@ AmplInterface::AmplInterface(int argc, char**& argv)
          C_val,
          &cols_res,
          const_cast<char*>("Map of variable names to variable ids")),
+      KW(const_cast<char*>("json"),
+         C_val,
+         &json_res,
+         const_cast<char*>("Name of output JSON file")),
       KW(const_cast<char*>("rows"),
          C_val,
          &rows_res,
@@ -141,6 +147,11 @@ AmplInterface::AmplInterface(int argc, char**& argv)
 
    _ASSERT_(stub != NULL, "ASL Error: nl filename pointer is NULL");
    stubname_ = std::string(stub);
+   if (json_res) {
+      jsonname_ = std::string(json_res);
+   } else {
+      jsonname_ = stubname_ + ".json";
+   }
 
    FILE* nl = NULL;
    nl = jac0dim(stub, (int)strlen(stub));

--- a/src/AmplInterface.hpp
+++ b/src/AmplInterface.hpp
@@ -39,6 +39,9 @@ public:
    // get the nl file stub name
    std::string get_stubname() const {return stubname_;}
 
+   // get the output json file name
+   std::string get_jsonname() const {return jsonname_;}
+
    // write a sol file
    void write_solution_file();
 
@@ -125,6 +128,9 @@ private:
 
    // stub file name
    std::string stubname_;
+
+   // json file name
+   std::string jsonname_;
 
    // keep track if which objective is being used
    int objn_;

--- a/src/gjh_asl_json.cpp
+++ b/src/gjh_asl_json.cpp
@@ -7,7 +7,7 @@ int main(int argc, char** argv)
 {
    AmplInterface solver(argc, argv);
 
-   std::string output_name = solver.get_stubname()+".json";
+   std::string output_name = solver.get_jsonname();
 
    std::ofstream out;
    out.open(output_name.c_str(), std::ios::out | std::ios::trunc);


### PR DESCRIPTION
This adds a "`json=`" command line option to `gjh_asl_json` so that the caller can specify that the JSON file is written to a different directory than the source NL stub.

The driver for this is to enable running package tests when the package is installed system-wide (i.e., into a directory where the user doesn't have write access). 