### PR TITLE
Add second URL to try when downloading ASL

### DIFF
--- a/Thirdparty/get.ASL
+++ b/Thirdparty/get.ASL
@@ -3,7 +3,8 @@
 set -e
 
 rm -f solvers.tgz
-wget http://www.ampl.com/netlib/ampl/solvers.tgz
+wget http://www.ampl.com/netlib/ampl/solvers.tgz \
+  || wget http://www.ampl.com/netlib/solvers.tgz
 rm -rf solvers
 tar xf solvers.tgz
 rm solvers.tgz


### PR DESCRIPTION
AMPL just changed how they forward URLs to netlib (removing the need for the `/ampl` in the url).  This PR updates get.ASL to try both URLs before failing.